### PR TITLE
Add PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ dev = [
 giteagle = "giteagle.cli.main:cli"
 
 [project.urls]
-Homepage = "https://github.com/pletisan/giteagle"
-Repository = "https://github.com/pletisan/giteagle"
+Homepage = "https://github.com/igormilovanovic/giteagle"
+Repository = "https://github.com/igormilovanovic/giteagle"
 
 [build-system]
 requires = ["hatchling"]


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that publishes to PyPI on release using trusted publishing (OIDC) — no API tokens needed
- Fixes project URLs in `pyproject.toml` to point to `igormilovanovic/giteagle`

Closes #7

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, configure trusted publisher on PyPI:
  1. Go to https://pypi.org/manage/account/publishing/
  2. Add pending publisher: owner=`igormilovanovic`, repo=`giteagle`, workflow=`publish.yml`, environment=`pypi`
- [ ] Create a GitHub environment named `pypi` in repo settings
- [ ] Create a GitHub release (e.g. `v0.1.0`) and verify the package appears on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)