### PR TITLE
Security hardening: credential leakage, file perms, input validation

### DIFF
--- a/demo/run_demo.sh
+++ b/demo/run_demo.sh
@@ -59,7 +59,7 @@ run_demo_command() {
 
     local output
     local exit_code=0
-    output=$(NO_COLOR=1 eval "${cmd}" 2>&1) || exit_code=$?
+    output=$(NO_COLOR=1 bash -c "${cmd}" 2>&1) || exit_code=$?
 
     output=$(printf '%s' "$output" | strip_ansi | strip_uv_warnings)
 

--- a/src/giteagle/cli/main.py
+++ b/src/giteagle/cli/main.py
@@ -25,7 +25,7 @@ T = TypeVar("T")
 
 def run_async(coro: Coroutine[Any, Any, T]) -> T:
     """Run an async function in the event loop."""
-    return asyncio.get_event_loop().run_until_complete(coro)
+    return asyncio.run(coro)
 
 
 def truncate_description(description: str | None, max_len: int = 50) -> str:


### PR DESCRIPTION
## Summary

Fixes multiple security issues identified during a code review:

- **[HIGH]** Validate `base_url` to HTTPS-only, preventing token exfiltration via config redirection
- **[HIGH]** Set `0o600` permissions on saved config files containing plaintext tokens
- **[MEDIUM]** Validate owner/name/org path segments against `^[a-zA-Z0-9._-]+$` to prevent path traversal
- **[MEDIUM]** Log warnings for failed async tasks instead of silently swallowing exceptions in `get_activities`
- **[MEDIUM]** Use timezone-aware `datetime.now(tz=timezone.utc)` fallback when timestamp parsing fails
- **[MEDIUM]** Replace `eval` with `bash -c` in demo script
- **[LOW]** Replace deprecated `asyncio.get_event_loop()` with `asyncio.run()`

Closes #11

## Test plan

- [x] Added tests for `base_url` HTTPS-only validation (accepts HTTPS, rejects HTTP, rejects missing hostname)
- [x] Added test for config file restrictive permissions (0o600)
- [x] Added tests for path segment validation (valid names, path traversal, slashes, empty, special chars)
- [x] Added integration-level tests for `get_repository` and `list_repositories` rejecting unsafe input
- [x] All 78 tests pass locally
- [x] Lint (`ruff check`), format (`ruff format --check`), and type-check (`mypy`) all pass
- [ ] CI passes across Python 3.9-3.12