### PR TITLE
Add TODO.md and attribution rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,3 +81,7 @@ uv run pytest --cov           # Test with coverage
 - Follow existing patterns in the codebase.
 - All code must pass `ruff check` and `ruff format --check`.
 - All code must pass `mypy` type checking.
+
+## Attribution
+
+- NEVER add AI-generated signatures, badges, or footers to commits, PRs, issues, or code. This includes lines like "Generated with Claude Code", "Co-Authored-By: Claude", or any similar attribution. All contributions should appear as normal developer contributions.

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,19 @@
+# TODO
+
+## High Priority
+
+- [ ] Add CLI tests (currently 0% coverage on all 5 commands)
+- [ ] Export to CSV/JSON (`--format json|csv` on CLI commands)
+- [ ] Expose activity filters on CLI (`--type commit`, `--author alice`, etc.)
+
+## Medium Priority
+
+- [ ] GitLab integration (base `PlatformClient` interface already exists)
+- [ ] Bitbucket integration (same pattern as GitLab)
+- [ ] Fix silent error suppression in timeline command (`except Exception: pass`)
+
+## Low Priority / Future
+
+- [ ] Slack/Discord notifications
+- [ ] Web dashboard
+- [ ] Team/group analytics


### PR DESCRIPTION
## Summary
- Add `TODO.md` with prioritized feature backlog (CLI tests, CSV/JSON export, activity filters, GitLab/Bitbucket)
- Add attribution rule to `CLAUDE.md` — no AI-generated signatures on commits, PRs, or code

## Test plan
- [x] Docs-only change, no code affected