### PR TITLE
fix(demo): factual, readable demo output

### DIFF
--- a/demo/DEMO.md
+++ b/demo/DEMO.md
@@ -1,6 +1,6 @@
 # Giteagle Demo: Kubernetes Ecosystem
 
-> **Generated on 2026-02-11 01:17:53 UTC**
+> **Generated on 2026-02-12 00:01:01 UTC**
 >
 > This demo showcases giteagle by querying real activity across the
 > [Kubernetes](https://github.com/kubernetes) GitHub organization.
@@ -42,194 +42,89 @@ $ uv run giteagle repos kubernetes --org
 ```
 
 ```
-                          Repositories for kubernetes                           
-╭─────────────────────────┬─────────────────────────┬────────────────┬─────────╮
-│ Name                    │ Description             │ Default Branch │ Private │
-├─────────────────────────┼─────────────────────────┼────────────────┼─────────┤
-│ kubernetes              │ Production-Grade        │ master         │ No      │
-│                         │ Container Scheduling    │                │         │
-│                         │ and Manageme...         │                │         │
-│ website                 │ Kubernetes website and  │ main           │ No      │
-│                         │ documentation repo:     │                │         │
-│ release                 │ Release infrastructure  │ master         │ No      │
-│                         │ for Kubernetes and      │                │         │
-│                         │ related ...             │                │         │
-│ minikube                │ Run Kubernetes locally  │ master         │ No      │
-│ test-infra              │ Test infrastructure for │ master         │ No      │
-│                         │ the Kubernetes project. │                │         │
-│ enhancements            │ Enhancements tracking   │ master         │ No      │
-│                         │ repo for Kubernetes     │                │         │
-│ community               │ Kubernetes community    │ master         │ No      │
-│                         │ content                 │                │         │
-│ kube-state-metrics      │ Add-on agent to         │ main           │ No      │
-│                         │ generate and expose     │                │         │
-│                         │ cluster-level ...       │                │         │
-│ node-problem-detector   │ This is a place for     │ master         │ No      │
-│                         │ various problem         │                │         │
-│                         │ detectors runn...       │                │         │
-│ kompose                 │ Convert Compose to      │ main           │ No      │
-│                         │ Kubernetes              │                │         │
-│ kops                    │ Kubernetes Operations   │ master         │ No      │
-│                         │ (kOps) - Production     │                │         │
-│                         │ Grade k8...             │                │         │
-│ kubernetes-template-pr… │ A template for starting │ main           │ No      │
-│                         │ new projects on the     │                │         │
-│                         │ github...               │                │         │
-│ git-sync                │ A sidecar app which     │ master         │ No      │
-│                         │ clones a git repo and   │                │         │
-│                         │ keeps it...             │                │         │
-│ k8s.io                  │ Code and configuration  │ main           │ No      │
-│                         │ to manage Kubernetes    │                │         │
-│                         │ projec...               │                │         │
-│ client-go               │ Go client for           │ master         │ No      │
-│                         │ Kubernetes.             │                │         │
-│ gengo                   │ gengo library for code  │ master         │ No      │
-│                         │ generation.             │                │         │
-│ perf-tests              │ Performance tests and   │ master         │ No      │
-│                         │ benchmarks              │                │         │
-│ ingress-nginx           │ Ingress NGINX           │ main           │ No      │
-│                         │ Controller for          │                │         │
-│                         │ Kubernetes              │                │         │
-│ kubeadm                 │ Aggregator for issues   │ main           │ No      │
-│                         │ filed against kubeadm   │                │         │
-│ repo-infra              │ Kubernetes repository   │ master         │ No      │
-│                         │ infrastucture tools     │                │         │
-│ dns                     │ Kubernetes DNS service  │ master         │ No      │
-│ apimachinery            │                         │ master         │ No      │
-│ apiserver               │ Library for writing a   │ master         │ No      │
-│                         │ Kubernetes-style API    │                │         │
-│                         │ server.                 │                │         │
-│ sample-apiserver        │ Reference               │ master         │ No      │
-│                         │ implementation of an    │                │         │
-│                         │ apiserver for a cus...  │                │         │
-│ kube-aggregator         │ Aggregator for          │ master         │ No      │
-│                         │ Kubernetes-style API    │                │         │
-│                         │ servers: dynam...       │                │         │
-│ metrics                 │ Kubernetes              │ master         │ No      │
-│                         │ metrics-related API     │                │         │
-│                         │ types and clients       │                │         │
-│ kubectl                 │ Issue tracker and       │ master         │ No      │
-│                         │ mirror of kubectl code  │                │         │
-│ autoscaler              │ Autoscaling components  │ master         │ No      │
-│                         │ for Kubernetes          │                │         │
-│ examples                │ Kubernetes application  │ master         │ No      │
-│                         │ example tutorials       │                │         │
-│ api                     │ The canonical location  │ master         │ No      │
-│                         │ of the Kubernetes API   │                │         │
-│                         │ defin...                │                │         │
-│ apiextensions-apiserver │ API server for API      │ master         │ No      │
-│                         │ extensions like         │                │         │
-│                         │ CustomResourceD...      │                │         │
-│ utils                   │ Non-Kubernetes-specific │ master         │ No      │
-│                         │ utility libraries which │                │         │
-│                         │ ar...                   │                │         │
-│ kube-openapi            │ Kubernetes OpenAPI spec │ master         │ No      │
-│                         │ generation & serving    │                │         │
-│ sig-release             │ Repo for SIG release    │ master         │ No      │
-│ code-generator          │ Generators for          │ master         │ No      │
-│                         │ kube-like API types     │                │         │
-│ steering                │ The Kubernetes Steering │ main           │ No      │
-│                         │ Committee               │                │         │
-│ ingress-gce             │ Ingress controller for  │ master         │ No      │
-│                         │ Google Cloud            │                │         │
-│ sample-controller       │ Repository for sample   │ master         │ No      │
-│                         │ controller. Complements │                │         │
-│                         │ samp...                 │                │         │
-│ publishing-bot          │ Code behind the robot   │ master         │ No      │
-│                         │ to publish from staging │                │         │
-│                         │ to r...                 │                │         │
-│ cloud-provider-aws      │ Cloud provider for AWS  │ master         │ No      │
-│ cloud-provider-opensta… │                         │ master         │ No      │
-│ cloud-provider-gcp      │ cloud-provider-gcp      │ master         │ No      │
-│                         │ contains several        │                │         │
-│                         │ projects used ...       │                │         │
-│ cloud-provider-vsphere  │ Kubernetes Cloud        │ master         │ No      │
-│                         │ Provider for vSphere    │                │         │
-│                         │ https://clou...         │                │         │
-│ org                     │ Meta configuration for  │ main           │ No      │
-│                         │ Kubernetes Github Org   │                │         │
-│ contributor-site        │ Code for kubernetes.dev │ master         │ No      │
-│ kube-controller-manager │ kube-controller-manager │ master         │ No      │
-│                         │ component configs       │                │         │
-│ kube-scheduler          │ kube-scheduler          │ master         │ No      │
-│                         │ component configs       │                │         │
-│ kubelet                 │ kubelet component       │ master         │ No      │
-│                         │ configs                 │                │         │
-│ kube-proxy              │ kube-proxy component    │ master         │ No      │
-│                         │ configs                 │                │         │
-│ cli-runtime             │ Set of helpers for      │ master         │ No      │
-│                         │ creating kubectl        │                │         │
-│                         │ commands and p...       │                │         │
-│ sample-cli-plugin       │ Sample kubectl plugin   │ master         │ No      │
-│ cloud-provider-alibaba… │ CloudProvider for       │ master         │ No      │
-│                         │ Alibaba Cloud           │                │         │
-│ cluster-bootstrap       │                         │ master         │ No      │
-│ cloud-provider          │ cloud-provider defines  │ master         │ No      │
-│                         │ the shared interfaces   │                │         │
-│                         │ which...                │                │         │
-│ klog                    │ Leveled execution logs  │ main           │ No      │
-│                         │ for Go (fork of         │                │         │
-│                         │ https://git...          │                │         │
-│ node-api                │                         │ master         │ No      │
-│ cloud-provider-sample   │ Sample of how to build  │ master         │ No      │
-│                         │ a cloud provider repo.  │                │         │
-│                         │ This...                 │                │         │
-│ component-base          │ Shared code for         │ master         │ No      │
-│                         │ kubernetes core         │                │         │
-│                         │ components              │                │         │
-│ csi-translation-lib     │ Staging repo for CSI    │ master         │ No      │
-│                         │ Migration/Translation   │                │         │
-│                         │ librari...              │                │         │
-│ committee-security-res… │ Kubernetes Security     │ main           │ No      │
-│                         │ Process and Security    │                │         │
-│                         │ Committee...            │                │         │
-│ cri-api                 │ Container Runtime       │ master         │ No      │
-│                         │ Interface (CRI) – a     │                │         │
-│                         │ plugin inter...         │                │         │
-│ legacy-cloud-providers  │ This repository hosts   │ master         │ No      │
-│                         │ the legacy in-tree      │                │         │
-│                         │ cloud pro...            │                │         │
-│ system-validators       │ A set of                │ main           │ No      │
-│                         │ system-oriented         │                │         │
-│                         │ validators for kubeadm  │                │         │
-│                         │ pr...                   │                │         │
-│ controller-manager      │ This repo is intended   │ master         │ No      │
-│                         │ to contain common       │                │         │
-│                         │ public lib...           │                │         │
-│ mount-utils             │ Package mount defines   │ master         │ No      │
-│                         │ an interface to         │                │         │
-│                         │ mounting fil...         │                │         │
-│ .github                 │ Default files for all   │ master         │ No      │
-│                         │ repos in the Kubernetes │                │         │
-│                         │ GitH...                 │                │         │
-│ component-helpers       │ High-level helpers for  │ master         │ No      │
-│                         │ Kubernetes components   │                │         │
-│ sig-testing             │ Home for SIG Testing    │ master         │ No      │
-│                         │ discussion and          │                │         │
-│                         │ documents.              │                │         │
-│ pod-security-admission  │ Kubernetes Pod Security │ master         │ No      │
-│                         │ Standards               │                │         │
-│                         │ implementation -...     │                │         │
-│ sig-security            │ Process documentation,  │ main           │ No      │
-│                         │ non-code deliverables,  │                │         │
-│                         │ and ...                 │                │         │
-│ design-proposals-archi… │ Archive of Kubernetes   │ main           │ No      │
-│                         │ Design Proposals        │                │         │
-│ registry.k8s.io         │ This project is the     │ main           │ No      │
-│                         │ repo for                │                │         │
-│                         │ registry.k8s.io, the    │                │         │
-│                         │ ...                     │                │         │
-│ kms                     │ Kubernetes KMS          │ master         │ No      │
-│                         │ implementation          │                │         │
-│ dynamic-resource-alloc… │                         │ master         │ No      │
-│ cel-admission-webhook   │                         │ main           │ No      │
-│ endpointslice           │                         │ master         │ No      │
-│ cri-client              │ Container Runtime       │ master         │ No      │
-│                         │ Interface client        │                │         │
-│                         │ implementation          │                │         │
-│ externaljwt             │ Synced from             │ master         │ No      │
-│                         │ kubernetes/kubernetes/… │                │         │
-╰─────────────────────────┴─────────────────────────┴────────────────┴─────────╯
+                                            Repositories for kubernetes                                            
+╭──────────────────────────────┬───────────────────────────────────────────────────────┬────────────────┬─────────╮
+│ Name                         │ Description                                           │ Default Branch │ Private │
+├──────────────────────────────┼───────────────────────────────────────────────────────┼────────────────┼─────────┤
+│ kubernetes                   │ Production-Grade Container Scheduling and Manageme... │ master         │ No      │
+│ website                      │ Kubernetes website and documentation repo:            │ main           │ No      │
+│ release                      │ Release infrastructure for Kubernetes and related ... │ master         │ No      │
+│ minikube                     │ Run Kubernetes locally                                │ master         │ No      │
+│ test-infra                   │ Test infrastructure for the Kubernetes project.       │ master         │ No      │
+│ enhancements                 │ Enhancements tracking repo for Kubernetes             │ master         │ No      │
+│ community                    │ Kubernetes community content                          │ master         │ No      │
+│ kube-state-metrics           │ Add-on agent to generate and expose cluster-level ... │ main           │ No      │
+│ node-problem-detector        │ This is a place for various problem detectors runn... │ master         │ No      │
+│ kompose                      │ Convert Compose to Kubernetes                         │ main           │ No      │
+│ kops                         │ Kubernetes Operations (kOps) - Production Grade k8... │ master         │ No      │
+│ kubernetes-template-project  │ A template for starting new projects on the github... │ main           │ No      │
+│ git-sync                     │ A sidecar app which clones a git repo and keeps it... │ master         │ No      │
+│ k8s.io                       │ Code and configuration to manage Kubernetes projec... │ main           │ No      │
+│ client-go                    │ Go client for Kubernetes.                             │ master         │ No      │
+│ gengo                        │ gengo library for code generation.                    │ master         │ No      │
+│ perf-tests                   │ Performance tests and benchmarks                      │ master         │ No      │
+│ ingress-nginx                │ Ingress NGINX Controller for Kubernetes               │ main           │ No      │
+│ kubeadm                      │ Aggregator for issues filed against kubeadm           │ main           │ No      │
+│ repo-infra                   │ Kubernetes repository infrastucture tools             │ master         │ No      │
+│ dns                          │ Kubernetes DNS service                                │ master         │ No      │
+│ apimachinery                 │                                                       │ master         │ No      │
+│ apiserver                    │ Library for writing a Kubernetes-style API server.    │ master         │ No      │
+│ sample-apiserver             │ Reference implementation of an apiserver for a cus... │ master         │ No      │
+│ kube-aggregator              │ Aggregator for Kubernetes-style API servers: dynam... │ master         │ No      │
+│ metrics                      │ Kubernetes metrics-related API types and clients      │ master         │ No      │
+│ kubectl                      │ Issue tracker and mirror of kubectl code              │ master         │ No      │
+│ autoscaler                   │ Autoscaling components for Kubernetes                 │ master         │ No      │
+│ examples                     │ Kubernetes application example tutorials              │ master         │ No      │
+│ api                          │ The canonical location of the Kubernetes API defin... │ master         │ No      │
+│ apiextensions-apiserver      │ API server for API extensions like CustomResourceD... │ master         │ No      │
+│ utils                        │ Non-Kubernetes-specific utility libraries which ar... │ master         │ No      │
+│ kube-openapi                 │ Kubernetes OpenAPI spec generation & serving          │ master         │ No      │
+│ sig-release                  │ Repo for SIG release                                  │ master         │ No      │
+│ code-generator               │ Generators for kube-like API types                    │ master         │ No      │
+│ steering                     │ The Kubernetes Steering Committee                     │ main           │ No      │
+│ ingress-gce                  │ Ingress controller for Google Cloud                   │ master         │ No      │
+│ sample-controller            │ Repository for sample controller. Complements samp... │ master         │ No      │
+│ publishing-bot               │ Code behind the robot to publish from staging to r... │ master         │ No      │
+│ cloud-provider-aws           │ Cloud provider for AWS                                │ master         │ No      │
+│ cloud-provider-openstack     │                                                       │ master         │ No      │
+│ cloud-provider-gcp           │ cloud-provider-gcp contains several projects used ... │ master         │ No      │
+│ cloud-provider-vsphere       │ Kubernetes Cloud Provider for vSphere https://clou... │ master         │ No      │
+│ org                          │ Meta configuration for Kubernetes Github Org          │ main           │ No      │
+│ contributor-site             │ Code for kubernetes.dev                               │ master         │ No      │
+│ kube-controller-manager      │ kube-controller-manager component configs             │ master         │ No      │
+│ kube-scheduler               │ kube-scheduler component configs                      │ master         │ No      │
+│ kubelet                      │ kubelet component configs                             │ master         │ No      │
+│ kube-proxy                   │ kube-proxy component configs                          │ master         │ No      │
+│ cli-runtime                  │ Set of helpers for creating kubectl commands and p... │ master         │ No      │
+│ sample-cli-plugin            │ Sample kubectl plugin                                 │ master         │ No      │
+│ cloud-provider-alibaba-cloud │ CloudProvider for Alibaba Cloud                       │ master         │ No      │
+│ cluster-bootstrap            │                                                       │ master         │ No      │
+│ cloud-provider               │ cloud-provider defines the shared interfaces which... │ master         │ No      │
+│ klog                         │ Leveled execution logs for Go (fork of https://git... │ main           │ No      │
+│ node-api                     │                                                       │ master         │ No      │
+│ cloud-provider-sample        │ Sample of how to build a cloud provider repo. This... │ master         │ No      │
+│ component-base               │ Shared code for kubernetes core components            │ master         │ No      │
+│ csi-translation-lib          │ Staging repo for CSI Migration/Translation librari... │ master         │ No      │
+│ committee-security-response  │ Kubernetes Security Process and Security Committee... │ main           │ No      │
+│ cri-api                      │ Container Runtime Interface (CRI) – a plugin inter... │ master         │ No      │
+│ legacy-cloud-providers       │ This repository hosts the legacy in-tree cloud pro... │ master         │ No      │
+│ system-validators            │ A set of system-oriented validators for kubeadm pr... │ main           │ No      │
+│ controller-manager           │ This repo is intended to contain common public lib... │ master         │ No      │
+│ mount-utils                  │ Package mount defines an interface to mounting fil... │ master         │ No      │
+│ .github                      │ Default files for all repos in the Kubernetes GitH... │ master         │ No      │
+│ component-helpers            │ High-level helpers for Kubernetes components          │ master         │ No      │
+│ sig-testing                  │ Home for SIG Testing discussion and documents.        │ master         │ No      │
+│ pod-security-admission       │ Kubernetes Pod Security Standards implementation -... │ master         │ No      │
+│ sig-security                 │ Process documentation, non-code deliverables, and ... │ main           │ No      │
+│ design-proposals-archive     │ Archive of Kubernetes Design Proposals                │ main           │ No      │
+│ registry.k8s.io              │ This project is the repo for registry.k8s.io, the ... │ main           │ No      │
+│ kms                          │ Kubernetes KMS implementation                         │ master         │ No      │
+│ dynamic-resource-allocation  │                                                       │ master         │ No      │
+│ cel-admission-webhook        │                                                       │ main           │ No      │
+│ endpointslice                │                                                       │ master         │ No      │
+│ cri-client                   │ Container Runtime Interface client implementation     │ master         │ No      │
+│ externaljwt                  │ Synced from kubernetes/kubernetes/staging/external... │ master         │ No      │
+╰──────────────────────────────┴───────────────────────────────────────────────────────┴────────────────┴─────────╯
 
 Total: 78 repositories
 ```
@@ -244,57 +139,30 @@ $ uv run giteagle activity kubernetes/kubernetes --days 7 --limit 15
 ```
 
 ```
-╭───────────────────────────────── Repository ─────────────────────────────────╮
-│ kubernetes/kubernetes                                                        │
-│ Production-Grade Container Scheduling and Management                         │
-╰──────────────────────────────────────────────────────────────────────────────╯
-                             Activity (last 7 days)                             
-╭──────────────┬────────────────────────┬───────────────────┬──────────────────╮
-│ Type         │ Title                  │ Author            │ Date             │
-├──────────────┼────────────────────────┼───────────────────┼──────────────────┤
-│ pull_request │ WIP: move go-runner    │ BenTheElder       │ 2026-02-11 00:59 │
-│              │ back to kubernetes     │                   │                  │
-│ commit       │ Merge pull request     │ k8s-ci-robot      │ 2026-02-11 00:42 │
-│              │ #135675 from           │                   │                  │
-│              │ richabanker/merged-di… │                   │                  │
-│ commit       │ Merge pull request     │ k8s-ci-robot      │ 2026-02-11 00:41 │
-│              │ #135395 from           │                   │                  │
-│              │ pohly/apimachinery-wa… │                   │                  │
-│ commit       │ Merge pull request     │ k8s-ci-robot      │ 2026-02-10 23:47 │
-│              │ #135256 from           │                   │                  │
-│              │ natasha41575/pod-gen-… │                   │                  │
-│ pull_request │ add dockerized go      │ BenTheElder       │ 2026-02-10 22:58 │
-│              │ cache chmod to  `make  │                   │                  │
-│              │ clean`                 │                   │                  │
-│ pull_request │ Pipe feature gate of   │ michaelasp        │ 2026-02-10 22:35 │
-│              │ unlockWhileProcessing  │                   │                  │
-│ pull_request │ Promote                │ troychiu          │ 2026-02-10 22:10 │
-│              │ DRAPrioritizedList to  │                   │                  │
-│              │ GA                     │                   │                  │
-│ commit       │ Merge pull request     │ k8s-ci-robot      │ 2026-02-10 21:30 │
-│              │ #136716 from           │                   │                  │
-│              │ yonizxz/concurrent-no… │                   │                  │
-│ commit       │ Merge pull request     │ k8s-ci-robot      │ 2026-02-10 21:30 │
-│              │ #134981 from           │                   │                  │
-│              │ haircommander/drop-cp… │                   │                  │
-│ commit       │ Merge pull request     │ k8s-ci-robot      │ 2026-02-10 19:54 │
-│              │ #136911 from           │                   │                  │
-│              │ pohly/dra-e2e-data-ra… │                   │                  │
-│ commit       │ Merge pull request     │ k8s-ci-robot      │ 2026-02-10 19:54 │
-│              │ #136734 from           │                   │                  │
-│              │ sunya-ch/sunya-ch/fix… │                   │                  │
-│ commit       │ Merge pull request     │ k8s-ci-robot      │ 2026-02-10 18:38 │
-│              │ #136826 from           │                   │                  │
-│              │ alvaroaleman/bumpv0.32 │                   │                  │
-│ commit       │ Merge pull request     │ k8s-ci-robot      │ 2026-02-10 18:38 │
-│              │ #136339 from           │                   │                  │
-│              │ ffromani/deprecate-cu… │                   │                  │
-│ pull_request │ test: fix the flaking  │ shwetha-s-poojary │ 2026-02-10 14:02 │
-│              │ TestWebhookConversion… │                   │                  │
-│ commit       │ CHANGELOG: Update      │ k8s-release-robot │ 2026-02-10 13:06 │
-│              │ directory for v1.32.12 │                   │                  │
-│              │ release                │                   │                  │
-╰──────────────┴────────────────────────┴───────────────────┴──────────────────╯
+╭───────────────────────────────────────────────────────────────────────── Repository ─────────────────────────────────────────────────────────────────────────╮
+│ kubernetes/kubernetes                                                                                                                                        │
+│ Production-Grade Container Scheduling and Management                                                                                                         │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+                                                Activity (last 7 days)                                                 
+╭──────────────┬─────────────────────────────────────────────────────────────────┬─────────────────┬──────────────────╮
+│ Type         │ Title                                                           │ Author          │ Date             │
+├──────────────┼─────────────────────────────────────────────────────────────────┼─────────────────┼──────────────────┤
+│ pull_request │ apiserver: bound checkClient retries and fix DelayFunc data ... │ tobiasworkstech │ 2026-02-11 23:57 │
+│ commit       │ Merge pull request #136729 from ahmedtd/podcert-pkcs10          │ k8s-ci-robot    │ 2026-02-11 23:13 │
+│ pull_request │ Fix RestartAllContainer restart quickly with single containe... │ yuanwang04      │ 2026-02-11 23:12 │
+│ pull_request │ Add tests for RestartAllContainers                              │ yuanwang04      │ 2026-02-11 23:05 │
+│ pull_request │ Fix LastTerminationStatus for RestartAllContainers              │ yuanwang04      │ 2026-02-11 23:02 │
+│ pull_request │ Keep logs when containers removed by RestartAllContainers       │ yuanwang04      │ 2026-02-11 22:58 │
+│ issue        │ kubelet: static pod manifest directory reads ALL non-hidden ... │ yg-codes        │ 2026-02-11 22:57 │
+│ pull_request │ Refactor etcd failure test to use nftables with iptables fal... │ kairosci        │ 2026-02-11 22:51 │
+│ commit       │ Merge pull request #136796 from kairosci/fix/kube-proxy-nfta... │ k8s-ci-robot    │ 2026-02-11 22:23 │
+│ pull_request │ WIP: switch server images to kube-log-runner                    │ BenTheElder     │ 2026-02-11 20:45 │
+│ pull_request │ Revert dv native in the validation-gen framework                │ lalitc375       │ 2026-02-11 19:41 │
+│ commit       │ pkg/proxy/nftables: fix kube-proxy crash with newer nftables... │ kairosci        │ 2026-02-11 19:00 │
+│ commit       │ Merge pull request #133427 from natasha41575/admitHandler       │ k8s-ci-robot    │ 2026-02-11 18:40 │
+│ commit       │ Merge pull request #136905 from bart0sh/PR222-e2e-fix-extend... │ k8s-ci-robot    │ 2026-02-11 16:26 │
+│ commit       │ Merge pull request #130918 from iPraveenParihar/e2e/add-snap... │ k8s-ci-robot    │ 2026-02-11 13:40 │
+╰──────────────┴─────────────────────────────────────────────────────────────────┴─────────────────┴──────────────────╯
 
 Total: 15 activities
 ```
@@ -311,37 +179,37 @@ $ uv run giteagle summary kubernetes/kubernetes kubernetes/minikube kubernetes/i
 ```
 Fetched 100 activities from kubernetes/kubernetes
 Fetched 61 activities from kubernetes/minikube
-Fetched 65 activities from kubernetes/ingress-nginx
-╭─────────────────────────── Summary (last 7 days) ────────────────────────────╮
-│ Total Activities: 190                                                        │
-│ Repositories: 3                                                              │
-│ Contributors: 56                                                             │
-╰──────────────────────────────────────────────────────────────────────────────╯
+Fetched 55 activities from kubernetes/ingress-nginx
+╭─────────────────────────────────────────────────────────────────── Summary (last 7 days) ────────────────────────────────────────────────────────────────────╮
+│ Total Activities: 180                                                                                                                                        │
+│ Repositories: 3                                                                                                                                              │
+│ Contributors: 56                                                                                                                                             │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
     By Activity Type    
                         
   Type           Count  
  ────────────────────── 
-  pull_request      92  
-  commit            59  
-  issue             39  
+  pull_request      93  
+  commit            69  
+  issue             18  
                         
              Top Contributors              
                                            
   Username                     Activities  
  ───────────────────────────────────────── 
-  k8s-ci-robot                         29  
-  everettraven                         27  
-  Gacko                                22  
+  k8s-ci-robot                         38  
   k8s-infra-cherrypick-robot           17  
   minikube-bot                         14  
+  Gacko                                12  
+  dependabot                           10  
                                            
               By Repository              
                                          
   Repository                 Activities  
  ─────────────────────────────────────── 
   kubernetes/kubernetes             100  
-  kubernetes/ingress-nginx           59  
-  kubernetes/minikube                31  
+  kubernetes/ingress-nginx           51  
+  kubernetes/minikube                29  
                                          
 ```
 
@@ -355,14 +223,14 @@ $ uv run giteagle timeline kubernetes/kubernetes kubernetes/minikube kubernetes/
 ```
 
 ```
-╭──────────────────────────────────────────────────────────────────────────────╮
-│ Activity Timeline (weekly)                                                   │
-╰──────────────────────────────────────────────────────────────────────────────╯
-2026-01-12: █████████████████████████ 228
-2026-01-19: ███████████████████ 176
-2026-01-26: ██████████████████████████████ 269
-2026-02-02: ████████████████████████████████████████ 355
-2026-02-09: ██████████████████ 167
+╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ Activity Timeline (weekly)                                                                                                                                   │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+2026-01-12: █████████████████████████ 209
+2026-01-19: █████████████████████ 176
+2026-01-26: █████████████████████████████ 239
+2026-02-02: ████████████████████████████████████████ 328
+2026-02-09: ████████████████████████████ 234
 ```
 
 
@@ -375,40 +243,22 @@ $ uv run giteagle log kubernetes/kubernetes kubernetes/minikube kubernetes/ingre
 ```
 
 ```
-Fetched 10 commits from kubernetes/kubernetes
+Fetched 6 commits from kubernetes/kubernetes
 Fetched 1 commits from kubernetes/minikube
 Fetched 4 commits from kubernetes/ingress-nginx
- ● 2026-02-11  kubernetes     46ac9df  Merge pull request #135675 from 
-richabanker/merged-discovery (merge)
- │             kubernetes     eb09a3c  Merge pull request #135395 from 
-pohly/apimachinery-wait-for-cache-sync (merge)
- ● 2026-02-10  kubernetes     99d4b4d  Merge pull request #135256 from 
-natasha41575/pod-gen-field (merge)
- │             kubernetes     870e292  Merge pull request #136716 from 
-yonizxz/concurrent-node-syncs-split (merge)
- │             kubernetes     c9534cb  Merge pull request #134981 from 
-haircommander/drop-cpu-load (merge)
- │             kubernetes     3e15c6f  Merge pull request #136911 from 
-pohly/dra-e2e-data-race (merge)
- │             kubernetes     1bb2e12  Merge pull request #136734 from 
-sunya-ch/sunya-ch/fix-gather-shared-id (merge)
- │             minikube       f750803  Build(deps): Bump the golang-org group 
-with 6 updates (#22647)
- │             kubernetes     65f09e6  Merge pull request #136826 from 
-alvaroaleman/bumpv0.32 (merge)
- │             kubernetes     e7f26c6  Merge pull request #136339 from 
-ffromani/deprecate-customcpucfsquota-fg-not-feature (merge)
- │             kubernetes     f425715  CHANGELOG: Update directory for v1.32.12 
-release
- │             ingress-nginx  efcd54f  Controller: Enable SSL Passthrough when 
-requested on before HTTP-only hosts. (#14555)
+ ● 2026-02-11  ingress-nginx  296ce3b  CI: Update Kubernetes to v1.35.1. (#14561)
+ │             kubernetes     54489c1  Merge pull request #136729 from ahmedtd/podcert-pkcs10 (merge)
+ │             kubernetes     04d82d9  Merge pull request #136796 from kairosci/fix/kube-proxy-nftables-udata (merge)
+ │             ingress-nginx  50faa99  Docs: Clarify PROXY protocol is not supported on GKE default load balancer. (#14558)
+ │             kubernetes     72ef5b3  pkg/proxy/nftables: fix kube-proxy crash with newer nftables versions
+ │             kubernetes     311071d  Merge pull request #133427 from natasha41575/admitHandler (merge)
+ │             kubernetes     7b21ce7  Merge pull request #136905 from bart0sh/PR222-e2e-fix-extended-resource-flake (merge)
+ │             kubernetes     8b09f92  Merge pull request #130918 from iPraveenParihar/e2e/add-snapshot-metadata (merge)
+ ● 2026-02-10  minikube       f750803  Build(deps): Bump the golang-org group with 6 updates (#22647)
+ │             ingress-nginx  efcd54f  Controller: Enable SSL Passthrough when requested on before HTTP-only hosts. (#14555)
  ● 2026-02-09  ingress-nginx  72d99b3  CI: Update Helm to v4.1.1. (#14552)
- │             ingress-nginx  a2341e5  Bump github/codeql-action from 4.32.0 to 
-4.32.2 in the actions group (#14544)
- │             ingress-nginx  ded3b60  Annotations: Use dedicated regular 
-expression for `proxy-cookie-domain`. (#14536)
 
-Total: 15 commits across 3 repositories
+Total: 11 commits across 3 repositories
 ```
 
 
@@ -419,83 +269,70 @@ $ uv run giteagle log kubernetes/kubernetes kubernetes/minikube --author k8s-ci-
 ```
 
 ```
-Fetched 43 commits from kubernetes/kubernetes
+Fetched 56 commits from kubernetes/kubernetes
 Fetched 1 commits from kubernetes/minikube
- ● 2026-02-11  kubernetes  46ac9df  Merge pull request #135675 from 
-richabanker/merged-discovery (merge)
- │             kubernetes  eb09a3c  Merge pull request #135395 from 
-pohly/apimachinery-wait-for-cache-sync (merge)
- ● 2026-02-10  kubernetes  99d4b4d  Merge pull request #135256 from 
-natasha41575/pod-gen-field (merge)
- │             kubernetes  870e292  Merge pull request #136716 from 
-yonizxz/concurrent-node-syncs-split (merge)
- │             kubernetes  c9534cb  Merge pull request #134981 from 
-haircommander/drop-cpu-load (merge)
- │             kubernetes  3e15c6f  Merge pull request #136911 from 
-pohly/dra-e2e-data-race (merge)
- │             kubernetes  1bb2e12  Merge pull request #136734 from 
-sunya-ch/sunya-ch/fix-gather-shared-id (merge)
- │             kubernetes  65f09e6  Merge pull request #136826 from 
-alvaroaleman/bumpv0.32 (merge)
- │             kubernetes  e7f26c6  Merge pull request #136339 from 
-ffromani/deprecate-customcpucfsquota-fg-not-feature (merge)
- │             kubernetes  7f890ab  Merge pull request #136802 from 
-pohly/fix-data-race-refs-populaterefs (merge)
- │             kubernetes  2a9b8ba  Merge pull request #136787 from 
-ahmedtd/bump-ctb (merge)
- │             kubernetes  01b283a  Merge pull request #136907 from 
-aojea/ipaddress_flake (merge)
- │             kubernetes  59cdded  Merge pull request #136901 from 
-Phaow/vac-fix (merge)
- │             kubernetes  4670994  Merge pull request #136898 from 
-carlory/kubeadm-ContainerRuntimeVersion-1-37 (merge)
- │             kubernetes  76b4a90  Merge pull request #136326 from 
-bart0sh/PR218-migrate-kubelet_node_status-to-contextual-logging (merge)
- │             kubernetes  65b1000  Merge pull request #135749 from 
-novahe/fix-defer-latency (merge)
- │             kubernetes  44dc4cb  Merge pull request #136888 from 
-neolit123/revert-136130-kubeadm_use_newclientset (merge)
- │             kubernetes  b6f27f1  Merge pull request #136856 from 
-pohly/dra-integration-timeouts (merge)
- │             kubernetes  0bb7533  Merge pull request #135464 from 
-MikeSpreitzer/better-concurrency-test-margin (merge)
- │             kubernetes  1955210  Merge pull request #134044 from 
-mcallzbl/master (merge)
- │             kubernetes  7b0310a  Merge pull request #136820 from 
-dims/update-otel-deps (merge)
- │             kubernetes  f693c45  Merge pull request #136775 from 
-atombrella/feature/activate_modernize_slicessort (merge)
- ● 2026-02-09  kubernetes  fc74562  Merge pull request #136808 from 
-nmn3m/kubelet-contextual-logging (merge)
- │             kubernetes  09e1c9f  Merge pull request #136455 from 
-pohly/client-go-simpleclient-undeprecation (merge)
- │             kubernetes  139e78d  Merge pull request #136337 from 
-pohly/dra-e2e-hostpath-image-selection (merge)
- │             kubernetes  e73221c  Merge pull request #136488 from 
-thockin/fix_bad_arg_name_in_dv (merge)
- │             kubernetes  a39c820  Merge pull request #136423 from 
-neolit123/1.36-remove-flex-volume-support-from-kubeadm (merge)
- │             kubernetes  97a2334  Merge pull request #136778 from 
-Jefftree/etcd-metrics-typo (merge)
- ● 2026-02-08  kubernetes  918b5ac  Merge pull request #136840 from 
-atombrella/feature/fmt_sprintf_unneeded (merge)
+ ● 2026-02-11  kubernetes  54489c1  Merge pull request #136729 from ahmedtd/podcert-pkcs10 (merge)
+ │             kubernetes  04d82d9  Merge pull request #136796 from kairosci/fix/kube-proxy-nftables-udata (merge)
+ │             kubernetes  311071d  Merge pull request #133427 from natasha41575/admitHandler (merge)
+ │             kubernetes  7b21ce7  Merge pull request #136905 from bart0sh/PR222-e2e-fix-extended-resource-flake (merge)
+ │             kubernetes  8b09f92  Merge pull request #130918 from iPraveenParihar/e2e/add-snapshot-metadata (merge)
+ │             kubernetes  45b9248  Merge pull request #136719 from pohly/e2e-gce-speedups (merge)
+ │             kubernetes  90a76aa  Merge pull request #136846 from carlory/update-cri-losing-support (merge)
+ │             kubernetes  9dc55d7  Merge pull request #135729 from yangjunmyfm192085/fixe2e2 (merge)
+ │             kubernetes  fce5bc2  Merge pull request #134316 from xigang/node_controller_pod (merge)
+ │             kubernetes  a79d324  Merge pull request #136927 from BenTheElder/clean-fix (merge)
+ │             kubernetes  7b99981  Merge pull request #136925 from michaelasp/pipeFeatureGate (merge)
+ │             kubernetes  b236451  Merge pull request #136928 from BenTheElder/cleanup-unused-env (merge)
+ │             kubernetes  46ac9df  Merge pull request #135675 from richabanker/merged-discovery (merge)
+ │             kubernetes  eb09a3c  Merge pull request #135395 from pohly/apimachinery-wait-for-cache-sync (merge)
+ ● 2026-02-10  kubernetes  99d4b4d  Merge pull request #135256 from natasha41575/pod-gen-field (merge)
+ │             kubernetes  870e292  Merge pull request #136716 from yonizxz/concurrent-node-syncs-split (merge)
+ │             kubernetes  c9534cb  Merge pull request #134981 from haircommander/drop-cpu-load (merge)
+ │             kubernetes  3e15c6f  Merge pull request #136911 from pohly/dra-e2e-data-race (merge)
+ │             kubernetes  1bb2e12  Merge pull request #136734 from sunya-ch/sunya-ch/fix-gather-shared-id (merge)
+ │             kubernetes  65f09e6  Merge pull request #136826 from alvaroaleman/bumpv0.32 (merge)
+ │             kubernetes  e7f26c6  Merge pull request #136339 from ffromani/deprecate-customcpucfsquota-fg-not-feature (merge)
+ │             kubernetes  7f890ab  Merge pull request #136802 from pohly/fix-data-race-refs-populaterefs (merge)
+ │             kubernetes  2a9b8ba  Merge pull request #136787 from ahmedtd/bump-ctb (merge)
+ │             kubernetes  01b283a  Merge pull request #136907 from aojea/ipaddress_flake (merge)
+ │             kubernetes  59cdded  Merge pull request #136901 from Phaow/vac-fix (merge)
+ │             kubernetes  4670994  Merge pull request #136898 from carlory/kubeadm-ContainerRuntimeVersion-1-37 (merge)
+ │             kubernetes  76b4a90  Merge pull request #136326 from bart0sh/PR218-migrate-kubelet_node_status-to-contextual-logging (merge)
+ │             kubernetes  65b1000  Merge pull request #135749 from novahe/fix-defer-latency (merge)
+ │             kubernetes  44dc4cb  Merge pull request #136888 from neolit123/revert-136130-kubeadm_use_newclientset (merge)
+ │             kubernetes  b6f27f1  Merge pull request #136856 from pohly/dra-integration-timeouts (merge)
+ │             kubernetes  0bb7533  Merge pull request #135464 from MikeSpreitzer/better-concurrency-test-margin (merge)
+ │             kubernetes  1955210  Merge pull request #134044 from mcallzbl/master (merge)
+ │             kubernetes  7b0310a  Merge pull request #136820 from dims/update-otel-deps (merge)
+ │             kubernetes  f693c45  Merge pull request #136775 from atombrella/feature/activate_modernize_slicessort (merge)
+ ● 2026-02-09  kubernetes  fc74562  Merge pull request #136808 from nmn3m/kubelet-contextual-logging (merge)
+ │             kubernetes  09e1c9f  Merge pull request #136455 from pohly/client-go-simpleclient-undeprecation (merge)
+ │             kubernetes  139e78d  Merge pull request #136337 from pohly/dra-e2e-hostpath-image-selection (merge)
+ │             kubernetes  e73221c  Merge pull request #136488 from thockin/fix_bad_arg_name_in_dv (merge)
 
-Total: 29 commits across 1 repositories
+Total: 38 commits across 1 repositories
 ```
 
 
 ## 7. Daily Standup Report
 
-Generate a standup-ready summary of recent activity across repositories. The `standup` command groups activities by repo and categorizes them as commits, PRs opened/merged/closed, and issues. It auto-detects the authenticated user when a GitHub token is set.
+Generate a standup-ready summary of recent activity across repositories. The `standup` command groups activities by repo and categorizes them as commits, PRs opened/merged/closed, and issues. Use `--author` to filter by contributor.
 
 ```bash
-$ uv run giteagle standup kubernetes/kubernetes kubernetes/ingress-nginx --days 3
+$ uv run giteagle standup kubernetes/kubernetes kubernetes/ingress-nginx --author k8s-ci-robot --days 3
 ```
 
 ```
 Fetched 200 activities from kubernetes/kubernetes
-Fetched 34 activities from kubernetes/ingress-nginx
-No activity for igormilovanovic since 2026-02-08
+Fetched 38 activities from kubernetes/ingress-nginx
+Standup for k8s-ci-robot since 2026-02-09 (Mon)
+──────────────────────────────────────────────────
+
+kubernetes/kubernetes (40 activities)
+  Commits (40): Merge pull request #136729 from ahmedtd/podcert-pk, Merge pull request #136796 from kairosci/fix/kube-, Merge pull request #133427 from 
+natasha41575/admit, Merge pull request #136905 from bart0sh/PR222-e2e-, Merge pull request #130918 from iPraveenParihar/e2
+
+Total: 40 activities across 1 repositories
 ```
 
 
@@ -504,1062 +341,92 @@ No activity for igormilovanovic since 2026-02-08
 Show all open pull requests across repos with review status, CI status, age, and labels. PRs older than `--stale` days are highlighted as stale.
 
 ```bash
-$ uv run giteagle prs kubernetes/kubernetes kubernetes/ingress-nginx --stale 7
+$ uv run giteagle prs kubernetes/ingress-nginx --stale 7
 ```
 
 ```
-Fetched 100 open PRs from kubernetes/kubernetes
 Fetched 44 open PRs from kubernetes/ingress-nginx
-                            Open Pull Requests (144)                            
-╭───────────────┬───┬───────────────────────┬──────┬──────────────┬─────────┬──╮
-│ Repo          │ … │ Author                │ Age  │ Reviews      │ CI      │  │
-├───────────────┼───┼───────────────────────┼──────┼──────────────┼─────────┼──┤
-│ kubernetes    │ … │ shawnhanx             │ 254w │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ shawnhanx             │ 234w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ shawnhanx             │ 228w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ shawnhanx             │ 228w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ shawnhanx             │ 226w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ tomaspinho            │ 203w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ aslafy-z              │ 202w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ chrisshino            │ 195w │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ + │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ alowde                │ 179w │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ kirs                  │ 171w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ hassenius             │ 157w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ HirazawaUi            │ 148w │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ ghostloda             │ 142w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ skitt                 │ 140w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ Spazzy757             │ 139w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ chotiwat              │ 123w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ machine424            │ 120w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ travisghansen         │ 118w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ 2 │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ skitt                 │ 117w │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ skitt                 │ 116w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ nefelim4ag            │ 115w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ DaGenix               │ 114w │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ omertuc               │ 112w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ toredash              │ 106w │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ barrykp               │ 105w │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ bmv126                │ 103w │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ PascalBourdier        │ 103w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ a │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ zvlb                  │ 101w │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ msvticket             │ 96w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ adrianmoisey          │ 94w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ defaulterrr           │ 93w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ towca                 │ 91w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ a │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ nmreadelf             │ 90w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ SOF3                  │ 87w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ g1franc               │ 85w  │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ gjkim42               │ 85w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ huutomerkki           │ 83w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ antomy-gc             │ 83w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ LionelJouin           │ 82w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ HirazawaUi            │ 82w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ linxiulei             │ 82w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ croemmich             │ 81w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ Ritikaa96             │ 79w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ BenTheElder           │ 79w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ 2339478391            │ 77w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ maxl99                │ 76w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ tlwr                  │ 75w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ hshiina               │ 74w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ hshiina               │ 74w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ vrutkovs              │ 73w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ chengjoey             │ 73w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ dsyer                 │ 72w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ JanSchep              │ 72w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ chengjoey             │ 71w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ huochexizhan          │ 71w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ linxiulei             │ 70w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ mneverov              │ 67w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ ajaychoudhary-hotstar │ 67w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ knrc                  │ 66w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ knrc                  │ 66w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ rexagod               │ 66w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ vrutkovs              │ 65w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ tkashem               │ 65w  │ approved (2) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ ffromani              │ 65w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ gavinkflam            │ 64w  │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ VannTen               │ 64w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ acumino               │ 63w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ motoki317             │ 63w  │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ bouaouda-achraf       │ 63w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ elizabeth-dev         │ 62w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ Tal-or                │ 61w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ badouralix            │ 61w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ pohly                 │ 61w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ + │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ elizabeth-dev         │ 61w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ elizabeth-dev         │ 61w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ GFriedrich            │ 61w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ pohly                 │ 61w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ tkashem               │ 61w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ a │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ qvalentin             │ 60w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ chessman              │ 60w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ sjlawton              │ 59w  │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ xyz-li                │ 59w  │ approved (3) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ pohly                 │ 59w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ + │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ pohly                 │ 59w  │ changes (1)  │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ pohly                 │ 59w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ HirazawaUi            │ 59w  │ pending      │ pending │  │
-│               │ : │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ SuperQ                │ 58w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ pando85               │ 57w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ jacekn                │ 57w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ esotsal               │ 55w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ carlory               │ 54w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ adriancuadrado        │ 54w  │ approved (2) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ vaibhav2107           │ 54w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ jm-franc              │ 54w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ zylxjtu               │ 53w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ AwesomePatrol         │ 52w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ rohansingh            │ 52w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ mochizuki875          │ 51w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ novahe                │ 51w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ a │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ lentzi90              │ 51w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ bart0sh               │ 51w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ yue9944882            │ 51w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ oliverguenther        │ 50w  │ changes (1)  │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ laozc                 │ 50w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ RichardoC             │ 50w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ davidxia              │ 50w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ atiratree             │ 50w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ emmanuel              │ 49w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ vrutkovs              │ 49w  │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ ania-borowiec         │ 49w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ cbandy                │ 48w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ HirazawaUi            │ 47w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ iPraveenParihar       │ 46w  │ approved (2) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ HirazawaUi            │ 46w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ aiburegit             │ 45w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ sgaist                │ 45w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ alexintech            │ 44w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ yude                  │ 44w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ ntnn                  │ 43w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ fasaxc                │ 43w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ HirazawaUi            │ 43w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ HirazawaUi            │ 43w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ mbergo                │ 42w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ xigang                │ 42w  │ approved (2) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ leonardoramosantos    │ 41w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ pravk03               │ 41w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ carlory               │ 40w  │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ rexagod               │ 40w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ jaehanbyun            │ 40w  │ approved (2) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ carlory               │ 39w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ ArangoGutierrez       │ 39w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ Chunxia202410         │ 38w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ dacohen               │ 38w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ yangjunmyfm192085     │ 38w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ shadowofs             │ 38w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ alimaazamat           │ 37w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ aryasoni98            │ 37w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ Chunxia202410         │ 37w  │ approved (1) │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ sreeram-venkitesh     │ 37w  │ pending      │ fail    │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ condaatje             │ 36w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ DerekTBrown           │ 36w  │ changes (1)  │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ kubernetes    │ … │ utam0k                │ 36w  │ approved (1) │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ jinjingroad           │ 33w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│ ingress-nginx │ … │ Vexali0n              │ 30w  │ pending      │ pending │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-│               │ … │                       │      │              │         │  │
-╰───────────────┴───┴───────────────────────┴──────┴──────────────┴─────────┴──╯
+                                                                    Open Pull Requests (44)                                                                     
+╭───────────────┬───────────────────────────────────────────┬───────────────────────┬──────┬──────────────┬─────────┬──────────────────────────────────────────╮
+│ Repo          │ PR                                        │ Author                │ Age  │ Reviews      │ CI      │ Labels                                   │
+├───────────────┼───────────────────────────────────────────┼───────────────────────┼──────┼──────────────┼─────────┼──────────────────────────────────────────┤
+│ ingress-nginx │ #8366 Allow overriding real_ip_recursive  │ tomaspinho            │ 203w │ pending      │ pending │ cncf-cla: yes, area/docs, size/L         │
+│ ingress-nginx │ #8385 feat(annotations): introduce        │ aslafy-z              │ 203w │ pending      │ pending │ cncf-cla: yes, area/docs, size/L         │
+│               │ enable-custom-http-er...                  │                       │      │              │         │                                          │
+│ ingress-nginx │ #8582 Adds strict match annotation +      │ chrisshino            │ 195w │ changes (1)  │ pending │ cncf-cla: yes, area/docs, size/L         │
+│               │ updated tests/docs                        │                       │      │              │         │                                          │
+│ ingress-nginx │ #9025 Add least_connections load          │ alowde                │ 179w │ changes (1)  │ pending │ cncf-cla: yes, area/docs, size/XL        │
+│               │ balancing algorithm.                      │                       │      │              │         │                                          │
+│ ingress-nginx │ #9239 Implement Consistent Hashing with   │ kirs                  │ 171w │ pending      │ pending │ cncf-cla: yes, size/XL, needs-rebase     │
+│               │ Bounded Loads                             │                       │      │              │         │                                          │
+│ ingress-nginx │ #9586 add default http health check       │ hassenius             │ 157w │ pending      │ pending │ cncf-cla: yes, size/M, needs-kind        │
+│ ingress-nginx │ #9977 Fix the error while setting         │ ghostloda             │ 142w │ pending      │ pending │ cncf-cla: yes, size/XS, needs-kind       │
+│               │ upstream peer                             │                       │      │              │         │                                          │
+│ ingress-nginx │ #10072 fix: issue where canary overwrites │ Spazzy757             │ 139w │ pending      │ pending │ cncf-cla: yes, size/L, kind/bug          │
+│               │ default backend                           │                       │      │              │         │                                          │
+│ ingress-nginx │ #10454 TCP Proxy: Fix corrupted hostname  │ chotiwat              │ 123w │ pending      │ pending │ cncf-cla: yes, size/L, kind/bug          │
+│               │ from partial con...                       │                       │      │              │         │                                          │
+│ ingress-nginx │ #10627 support 2 tier control over        │ travisghansen         │ 118w │ pending      │ pending │ cncf-cla: yes, size/M, needs-ok-to-test  │
+│               │ sticky_persistent sess...                 │                       │      │              │         │                                          │
+│ ingress-nginx │ #10686 Ingress Status: Improve checking   │ nefelim4ag            │ 115w │ pending      │ pending │ cncf-cla: yes, size/L, needs-rebase      │
+│               │ for rollover or s...                      │                       │      │              │         │                                          │
+│ ingress-nginx │ #10912 docs: update otel documentation    │ toredash              │ 107w │ approved (1) │ pending │ cncf-cla: yes, area/docs, size/M         │
+│ ingress-nginx │ #10990 Add support to make delay, size,   │ bmv126                │ 103w │ pending      │ fail    │ cncf-cla: yes, area/docs, size/L         │
+│               │ burst configurabl...                      │                       │      │              │         │                                          │
+│ ingress-nginx │ #11046 Acceleration update Endpoints      │ zvlb                  │ 101w │ pending      │ pending │ cncf-cla: yes, size/L, kind/feature      │
+│ ingress-nginx │ #11294 Template: Distinguish paths with   │ adrianmoisey          │ 94w  │ pending      │ pending │ cncf-cla: yes, size/L, kind/bug          │
+│               │ different types.                          │                       │      │              │         │                                          │
+│ ingress-nginx │ #11333 Controller/Store: Retrieve         │ defaulterrr           │ 93w  │ pending      │ pending │ cncf-cla: yes, size/L, kind/feature      │
+│               │ `EndpointSlices` by `Se...                │                       │      │              │         │                                          │
+│ ingress-nginx │ #11490 Annotation: Make                   │ g1franc               │ 85w  │ changes (1)  │ pending │ cncf-cla: yes, size/M, kind/bug          │
+│               │ `proxy-ssl-secret` optional.              │                       │      │              │         │                                          │
+│ ingress-nginx │ #11655 Accept wildcard in                 │ croemmich             │ 81w  │ pending      │ pending │ cncf-cla: yes, size/S, kind/feature      │
+│               │ nginx.ingress.kubernetes.io/cor...        │                       │      │              │         │                                          │
+│ ingress-nginx │ #11830 Canary Weighted Consistent Hashing │ 2339478391            │ 77w  │ pending      │ pending │ cncf-cla: yes, area/docs, size/L         │
+│ ingress-nginx │ #11843 TCP Proxy: Fix TLS passthrough for │ maxl99                │ 77w  │ approved (1) │ pending │ cncf-cla: yes, size/M, kind/bug          │
+│               │ fragmented Clie...                        │                       │      │              │         │                                          │
+│ ingress-nginx │ #11968 fix `ipallowlist` parser not       │ chengjoey             │ 73w  │ pending      │ pending │ cncf-cla: yes, size/M, needs-kind        │
+│               │ handling `validation`...                  │                       │      │              │         │                                          │
+│ ingress-nginx │ #12034 Fix: nginx proxy server list not   │ chengjoey             │ 71w  │ pending      │ fail    │ cncf-cla: yes, size/M, needs-rebase      │
+│               │ changed                                   │                       │      │              │         │                                          │
+│ ingress-nginx │ #12228 Fix make clean                     │ mneverov              │ 68w  │ pending      │ pending │ cncf-cla: yes, size/S, needs-kind        │
+│ ingress-nginx │ #12256 Added label for upstream cache hit │ ajaychoudhary-hotstar │ 67w  │ pending      │ pending │ cncf-cla: yes, size/L, needs-rebase      │
+│               │ status                                    │                       │      │              │         │                                          │
+│ ingress-nginx │ #12384 Config/Annotations: Add            │ gavinkflam            │ 64w  │ changes (1)  │ pending │ cncf-cla: yes, area/docs, size/L         │
+│               │ `ssl-forbid-http` and `for...             │                       │      │              │         │                                          │
+│ ingress-nginx │ #12397 Improve shutdown logic: Wait until │ motoki317             │ 63w  │ changes (1)  │ pending │ cncf-cla: yes, size/L, kind/feature      │
+│               │ no requests are...                        │                       │      │              │         │                                          │
+│ ingress-nginx │ #12424 Template: Fix faulty CORS headers  │ elizabeth-dev         │ 63w  │ approved (1) │ pending │ cncf-cla: yes, size/XL, kind/bug         │
+│               │ handling.                                 │                       │      │              │         │                                          │
+│ ingress-nginx │ #12447 NGINX: Migrate auth cache key to   │ elizabeth-dev         │ 61w  │ approved (1) │ pending │ cncf-cla: yes, size/S, kind/feature      │
+│               │ NJS.                                      │                       │      │              │         │                                          │
+│ ingress-nginx │ #12448 NGINX: Migrate server redirects to │ elizabeth-dev         │ 61w  │ approved (1) │ fail    │ cncf-cla: yes, size/M, kind/feature      │
+│               │ NJS.                                      │                       │      │              │         │                                          │
+│ ingress-nginx │ #12450 Switch default OTel sampler to     │ GFriedrich            │ 61w  │ pending      │ pending │ cncf-cla: yes, area/docs, size/M         │
+│               │ TraceIdRatioBased                         │                       │      │              │         │                                          │
+│ ingress-nginx │ #12479 test(customheaders): add test for  │ qvalentin             │ 60w  │ pending      │ pending │ cncf-cla: yes, size/M, kind/bug          │
+│               │ annotation added                          │                       │      │              │         │                                          │
+│ ingress-nginx │ #12480 Controller: Retain default backend │ chessman              │ 60w  │ pending      │ pending │ cncf-cla: yes, size/XS, needs-ok-to-test │
+│               │ service informa...                        │                       │      │              │         │                                          │
+│ ingress-nginx │ #12521 Docs: Document                     │ sjlawton              │ 60w  │ changes (1)  │ pending │ cncf-cla: yes, area/docs, size/XS        │
+│               │ `client-body-timeout` annotation.         │                       │      │              │         │                                          │
+│ ingress-nginx │ #12626 Annotations: Allow `@` in URLs.    │ pando85               │ 57w  │ pending      │ pending │ cncf-cla: yes, size/XS, needs-ok-to-test │
+│ ingress-nginx │ #12638 Improve HTTP method label handling │ jacekn                │ 57w  │ pending      │ pending │ cncf-cla: yes, size/M, needs-ok-to-test  │
+│               │ in prometheus m...                        │                       │      │              │         │                                          │
+│ ingress-nginx │ #12817 Allow keepalives on status port    │ rohansingh            │ 52w  │ pending      │ pending │ cncf-cla: yes, size/XS, needs-ok-to-test │
+│ ingress-nginx │ #12878 Config: Do not log URL parameters. │ RichardoC             │ 50w  │ approved (1) │ pending │ cncf-cla: yes, lgtm, area/docs           │
+│ ingress-nginx │ #12912 feat: Parameterize config paths.   │ emmanuel              │ 49w  │ pending      │ pending │ cncf-cla: yes, size/M, needs-ok-to-test  │
+│               │ Fixes #12911.                             │                       │      │              │         │                                          │
+│ ingress-nginx │ #13157 Fix kubectl plugin release         │ alexintech            │ 44w  │ pending      │ pending │ cncf-cla: yes, size/M, needs-ok-to-test  │
+│ ingress-nginx │ #13264 Use PCRE on proxy redirect         │ leonardoramosantos    │ 42w  │ pending      │ pending │ cncf-cla: yes, size/S, kind/bug          │
+│               │ property                                  │                       │      │              │         │                                          │
+│ ingress-nginx │ #13374 Location regex should respect      │ dacohen               │ 38w  │ pending      │ fail    │ cncf-cla: yes, size/M, needs-rebase      │
+│               │ Exact paths                               │                       │      │              │         │                                          │
+│ ingress-nginx │ #13444 Controller: Correctly identify     │ DerekTBrown           │ 36w  │ changes (1)  │ pending │ cncf-cla: yes, area/docs, size/L         │
+│               │ other pods on shutd...                    │                       │      │              │         │                                          │
+│ ingress-nginx │ #13535 refactor: use slices.Contains to   │ jinjingroad           │ 33w  │ pending      │ pending │ cncf-cla: yes, size/M, needs-ok-to-test  │
+│               │ simplify code                             │                       │      │              │         │                                          │
+│ ingress-nginx │ #13609 Dynamic OCSP cache invalidation    │ Vexali0n              │ 30w  │ pending      │ pending │ cncf-cla: yes, size/M, needs-ok-to-test  │
+╰───────────────┴───────────────────────────────────────────┴───────────────────────┴──────┴──────────────┴─────────┴──────────────────────────────────────────╯
 ```
 
-
-## 9. DORA-Style PR Metrics
-
-Track engineering velocity with DORA-inspired metrics: median time-to-merge (TTM), median time-to-first-review (TTFR), merge rate, and PR throughput per week. Includes trend comparison (up/down/stable) vs the previous period.
-
-```bash
-$ uv run giteagle stats kubernetes/kubernetes kubernetes/ingress-nginx --days 30
-```
-
-```
-Warning: Failed to fetch kubernetes/kubernetes: HTTP 500
-Fetched 198 closed PRs from kubernetes/ingress-nginx
-                           PR Metrics (last 30 days)                           
-╭───────────────┬────────┬────────────┬─────────────┬────────────┬────────────╮
-│ Repo          │ Merged │ Median TTM │ Median TTFR │ Merge Rate │ PRs/week   │
-├───────────────┼────────┼────────────┼─────────────┼────────────┼────────────┤
-│ ingress-nginx │    169 │ 1h 5m      │ 11m         │        93% │ 39.4  ^ up │
-╰───────────────┴────────┴────────────┴─────────────┴────────────┴────────────╯
-```
-
----
-
-*Demo completed at 2026-02-11 01:19:11 UTC.*
-*Run with giteagle, version 0.1.0.*

--- a/demo/run_demo.sh
+++ b/demo/run_demo.sh
@@ -59,7 +59,7 @@ run_demo_command() {
 
     local output
     local exit_code=0
-    output=$(NO_COLOR=1 bash -c "${cmd}" 2>&1) || exit_code=$?
+    output=$(NO_COLOR=1 COLUMNS=160 bash -c "${cmd}" 2>&1) || exit_code=$?
 
     output=$(printf '%s' "$output" | strip_ansi | strip_uv_warnings)
 
@@ -146,7 +146,7 @@ run_demo_command \
     echo ""
 } >> "$OUTPUT_FILE"
 
-OUTPUT_LOG=$(NO_COLOR=1 bash -c "uv run giteagle log ${K8S_CORE} ${K8S_MINIKUBE} --author k8s-ci-robot --days 3" 2>&1 | strip_ansi | strip_uv_warnings)
+OUTPUT_LOG=$(NO_COLOR=1 COLUMNS=160 bash -c "uv run giteagle log ${K8S_CORE} ${K8S_MINIKUBE} --author k8s-ci-robot --days 3" 2>&1 | strip_ansi | strip_uv_warnings)
 {
     echo '```'
     echo "${OUTPUT_LOG}"
@@ -157,20 +157,20 @@ OUTPUT_LOG=$(NO_COLOR=1 bash -c "uv run giteagle log ${K8S_CORE} ${K8S_MINIKUBE}
 run_demo_command \
     "7" \
     "Daily Standup Report" \
-    "Generate a standup-ready summary of recent activity across repositories. The \`standup\` command groups activities by repo and categorizes them as commits, PRs opened/merged/closed, and issues. It auto-detects the authenticated user when a GitHub token is set." \
-    "uv run giteagle standup ${K8S_CORE} ${K8S_INGRESS} --days 3"
+    "Generate a standup-ready summary of recent activity across repositories. The \`standup\` command groups activities by repo and categorizes them as commits, PRs opened/merged/closed, and issues. Use \`--author\` to filter by contributor." \
+    "uv run giteagle standup ${K8S_CORE} ${K8S_INGRESS} --author k8s-ci-robot --days 3"
 
 run_demo_command \
     "8" \
     "Cross-Repo PR Dashboard" \
     "Show all open pull requests across repos with review status, CI status, age, and labels. PRs older than \`--stale\` days are highlighted as stale." \
-    "uv run giteagle prs ${K8S_CORE} ${K8S_INGRESS} --stale 7"
+    "uv run giteagle prs ${K8S_INGRESS} --stale 7"
 
 run_demo_command \
     "9" \
     "DORA-Style PR Metrics" \
     "Track engineering velocity with DORA-inspired metrics: median time-to-merge (TTM), median time-to-first-review (TTFR), merge rate, and PR throughput per week. Includes trend comparison (up/down/stable) vs the previous period." \
-    "uv run giteagle stats ${K8S_CORE} ${K8S_INGRESS} --days 30"
+    "uv run giteagle stats ${K8S_MINIKUBE} ${K8S_INGRESS} --days 30"
 
 # --- Footer ---
 


### PR DESCRIPTION
## Summary

- Use `--author k8s-ci-robot` for standup demo so it shows real activity instead of "No activity for igormilovanovic"
- Use only `kubernetes/ingress-nginx` for PR dashboard (44 readable PRs instead of 144 with truncated titles)
- Replace `kubernetes/kubernetes` with `kubernetes/minikube` in stats demo (avoids HTTP 500)
- Set `COLUMNS=160` in demo command runner so Rich tables render with full content
- Regenerated DEMO.md with verified live data (spot-checked PRs, commits, and age calculations against GitHub API)

## Test plan

- [ ] Run `GITHUB_TOKEN=$(gh auth token) bash demo/run_demo.sh` and verify all 9 sections produce readable output
- [ ] Verify DEMO.md contains no "No activity" messages or HTTP error warnings
- [ ] Spot-check a few PR numbers/commit SHAs against GitHub to confirm data is real

Closes #26