### PR TITLE
feat(ci): add bandit static security analysis to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,3 +80,6 @@ jobs:
 
       - name: Run pip-audit
         run: uv run pip-audit
+
+      - name: Run bandit
+        run: uv run bandit -r src/ -c pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     "mypy>=1.0.0",
     "types-PyYAML>=6.0.0",
     "pip-audit>=2.0",
+    "bandit>=1.9.4",
 ]
 
 [tool.pytest.ini_options]
@@ -110,3 +111,7 @@ python_version = "3.14"
 warn_return_any = true
 warn_unused_ignores = true
 disallow_untyped_defs = true
+
+[tool.bandit]
+targets = ["src"]
+severity = "medium"

--- a/src/giteagle/cli/main.py
+++ b/src/giteagle/cli/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Coroutine
 from datetime import UTC, datetime, timedelta
 from typing import Any
@@ -22,6 +23,7 @@ from giteagle.config import load_config
 from giteagle.core import ActivityAggregator, ActivityType
 from giteagle.integrations import GitHubClient
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 
@@ -268,7 +270,7 @@ def timeline(ctx: click.Context, repos: tuple, days: int, granularity: str) -> N
                     activities = await client.get_activities(repository, since=since, limit=500)
                     aggregator.add_activities(activities)
                 except Exception:
-                    pass
+                    logger.warning("Failed to fetch activities for %s", repo_name, exc_info=True)
 
             return aggregator
 
@@ -400,7 +402,10 @@ def standup(ctx: click.Context, repos: tuple, days: int, author: str | None) -> 
                 try:
                     resolved_author = await client.get_authenticated_user()
                 except Exception:
-                    pass
+                    logger.warning(
+                        "Could not resolve authenticated user; author filter disabled",
+                        exc_info=True,
+                    )
 
             all_activities: list = []
             for repo_name in repos:

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,21 @@ wheels = [
 ]
 
 [[package]]
+name = "bandit"
+version = "1.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "stevedore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c3/0cb80dfe0f3076e5da7e4c5ad8e57bac6ac357ff4a6406205501cade4965/bandit-1.9.4.tar.gz", hash = "sha256:b589e5de2afe70bd4d53fa0c1da6199f4085af666fde00e8a034f152a52cd628", size = 4242677, upload-time = "2026-02-25T06:44:15.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/a4/a26d5b25671d27e03afb5401a0be5899d94ff8fab6a698b1ac5be3ec29ef/bandit-1.9.4-py3-none-any.whl", hash = "sha256:f89ffa663767f5a0585ea075f01020207e966a9c0f2b9ef56a57c7963a3f6f8e", size = 134741, upload-time = "2026-02-25T06:44:13.694Z" },
+]
+
+[[package]]
 name = "boolean-py"
 version = "5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -208,6 +223,7 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "bandit" },
     { name = "mypy" },
     { name = "pip-audit" },
     { name = "pytest" },
@@ -238,6 +254,7 @@ provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "bandit", specifier = ">=1.9.4" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "pip-audit", specifier = ">=2.0" },
     { name = "pytest", specifier = ">=7.0.0" },
@@ -765,6 +782,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
+]
+
+[[package]]
+name = "stevedore"
+version = "5.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/dd/04d56c2a5232358df41f3d0f0e31833d378b6c8ed7803a6b1b7867b0eba6/stevedore-5.9.0.tar.gz", hash = "sha256:abbd0af7a38a8bbb1d6adea2e35b17609cf004eaac323e88a8d8963640dd2b3c", size = 514850, upload-time = "2026-07-02T11:38:08.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/8d/008761f6e1000600e5303db30d05724bdcf3d2d186cbb59fac79b52e39ed/stevedore-5.9.0-py3-none-any.whl", hash = "sha256:e520945d4c257700eddc1eb1d79df04b2ea578eef185e0e3fa5b442fc848d3f7", size = 54463, upload-time = "2026-07-02T11:38:07.43Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `bandit` to the `security` CI job alongside `pip-audit`, scanning source code for common security issues (hardcoded secrets, `eval`, insecure subprocess calls, etc.) on every push and PR
- Adds `bandit>=1.7` to the dev dependency group in `pyproject.toml`
- Adds `[tool.bandit]` config block targeting `src/` at medium+ severity
- Fixes two B110 (`try_except_pass`) findings in `cli/main.py` by replacing silent `except/pass` with `logger.warning()` calls, per the project's error handling rules (adds `logging` import and `logger` module-level instance)

## Test plan

- [ ] All three CI jobs pass: `test`, `lint`, `security`
- [ ] `uv run bandit -r src/ -c pyproject.toml` returns "No issues identified"
- [ ] `uv run pip-audit` returns "No known vulnerabilities found"

Closes #32